### PR TITLE
Fix weesetup build

### DIFF
--- a/grubutils/weesetup/Makefile
+++ b/grubutils/weesetup/Makefile
@@ -38,9 +38,10 @@ extra_CLEAN = mbr.h
 
 weesetup.o: mbr.h
 weesetup$(EXEEXT): weesetup.o xdio.o utils.o
+	mkdir -p bin
 	$(CC) $(CFLAGS) -s -obin/$@ $^
 	rm *.o *.d mbr.h
 mbr.h: wee63.mbr $(BIN2H_DEPS)
-	./$(BIN2H_EXEC) $< $@ wee63_mbr
+	$(BIN2H_EXEC) $< $@ wee63_mbr
 wee63.mbr: nt6mbr.bin ../wee/wee63.mbr
-	./mkmbr
+	sh mkmbr

--- a/grubutils/weesetup/weesetup.c
+++ b/grubutils/weesetup/weesetup.c
@@ -116,7 +116,7 @@ static void open_dev( device_t *dev, char *name )
    dev->name = name;
    if( *name == '(' )
    {
-      dev->xd = xd_open( name, 1 );
+      dev->xd = xd_open( name, 1, 1 );
       dev->fd = -1;
    }
    else
@@ -263,7 +263,7 @@ void list_devs (void)
       xd_t *xd;
 
       sprintf (name, "(hd%d)", i);
-      xd = xd_open (name, 1);
+      xd = xd_open ( name, 1, 1 );
       if (xd)
       {
          unsigned long size;
@@ -874,7 +874,7 @@ int main( int argc, char *argv[] )
 
    fs = get_fstype( (unsigned char*)read_data );
 
-   if( fs == FST_MBR2 )
+   if( fs == FST_MBR )
    {
       if( install_flag & FLAG_FORCE )
       {


### PR DESCRIPTION
compile wee/ [OK]
compile weesetup/ [ERROR]

GCC 4.6 4.7 4.8 & 4.9 throw many errors, like this:

```
# make
./mkmbr
make: execvp: ./mkmbr: Permission denied
make: *** [wee63.mbr] Error 127

# make
sh mkmbr
63+0 records in
63+0 records out
32256 bytes (32 kB) copied, 0.000770783 s, 41.8 MB/s
31527+0 records in
31527+0 records out
31527 bytes (32 kB) copied, 0.148295 s, 213 kB/s
1+0 records in
1+0 records out
512 bytes (512 B) copied, 0.000164523 s, 3.1 MB/s
./perl ../common/bin2h.pl wee63.mbr mbr.h wee63_mbr
make: ./perl: Command not found
make: *** [mbr.h] Error 127

# make
perl ../common/bin2h.pl wee63.mbr mbr.h wee63_mbr
gcc -I../common/ -I. -Wall -DLINUX -c -MMD -o weesetup.o weesetup.c
weesetup.c: In function ‘open_dev’:
weesetup.c:119:7: error: too few arguments to function ‘xd_open’
../common/xdio.h:72:7: note: declared here
weesetup.c: In function ‘list_devs’:
weesetup.c:266:7: error: too few arguments to function ‘xd_open’
../common/xdio.h:72:7: note: declared here
weesetup.c: In function ‘main’:
weesetup.c:877:14: error: ‘FST_MBR2’ undeclared (first use in this function)
weesetup.c:877:14: note: each undeclared identifier is reported only once for each function it appears in
make: *** [weesetup.o] Error 1

# make
gcc -I../common/ -I. -Wall -DLINUX -c -MMD -o weesetup.o weesetup.c
weesetup.c: In function ‘main’:
weesetup.c:877:14: error: ‘FST_MBR2’ undeclared (first use in this function)
weesetup.c:877:14: note: each undeclared identifier is reported only once for each function it appears in
make: *** [weesetup.o] Error 1

# make
gcc -I../common/ -I. -Wall -DLINUX -c -MMD -o weesetup.o weesetup.c
gcc -I../common/ -I. -Wall -DLINUX -c -MMD -o xdio.o ../common/xdio.c
gcc -I../common/ -I. -Wall -DLINUX -c -MMD -o utils.o ../common/utils.c
gcc -I../common/ -I. -Wall -DLINUX -s -obin/weesetup weesetup.o xdio.o utils.o
/usr/bin/ld: cannot open output file bin/weesetup: No such file or directory
collect2: ld returned 1 exit status
make: *** [weesetup] Error 1

OK
mkdir -p bin
gcc -I../common/ -I. -Wall -DLINUX -s -obin/weesetup weesetup.o xdio.o utils.o
rm *.o *.d mbr.h
```
